### PR TITLE
Fix bug with __match_args__

### DIFF
--- a/lib/recordclass/datatype.py
+++ b/lib/recordclass/datatype.py
@@ -102,7 +102,7 @@ class datatype(type):
             options['immutable_type'] = immutable_type
 
         if '__match_args__' in ns:
-            options['match'] = ns[__match_args__]            
+            options['match'] = ns['__match_args__']            
 
         is_dataobject = is_datastruct = False
         if bases:


### PR DESCRIPTION
Properly uses `'__match_args__'` from the ns dictionary, instead of a nonexistent `__match_args__` variable